### PR TITLE
Fix error when someone come online

### DIFF
--- a/addon/addon.lua
+++ b/addon/addon.lua
@@ -90,6 +90,7 @@ setmetatable(Prat, am)
 
 
 Prat.Prat3 = true
+Prat.IsClassic = (_G.WOW_PROJECT_ID == _G.WOW_PROJECT_CLASSIC)
 
 local function dbg(...) end
 

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -602,7 +602,6 @@ Prat:AddModuleToLoad(function()
 
   function module:updateWho()
     if self.wholib then return end
-    if Prat.IsClassic then return end
 
     local Name, Class, Level, Server, _
     for i = 1, GetNumWhoResults() do

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -602,6 +602,7 @@ Prat:AddModuleToLoad(function()
 
   function module:updateWho()
     if self.wholib then return end
+    if Prat.IsClassic then return end
 
     local Name, Class, Level, Server, _
     for i = 1, GetNumWhoResults() do


### PR DESCRIPTION
This patch fixes the issue for

`9x Prat-3.0-3.2.28\modules\PlayerNames.lua:1256: attempt to call global 'GetNumWhoResults' (a nil value)`

Now sure if this is the best way to go but it at least makes the error disappear...