### PR TITLE
Hide Blizzard chat timestamps when using the Timestamps module

### DIFF
--- a/modules/Timestamps.lua
+++ b/modules/Timestamps.lua
@@ -247,8 +247,7 @@ Prat:AddModuleToLoad(function()
     end
 
     -- Disable blizz timestamps
---    SetCVar("showTimestamps", "none")
---    InterfaceOptionsSocialPanelTimestamps.cvar = "none"
+    self:RawHook("ChatFrame_MessageEventHandler", true)
 
     self:RawHook("ChatChannelDropDown_PopOutChat", true)
 
@@ -264,6 +263,14 @@ Prat:AddModuleToLoad(function()
   end
 
   local hookedFrames = {}
+
+  function module:ChatFrame_MessageEventHandler(...)
+    local ctsf = CHAT_TIMESTAMP_FORMAT
+    CHAT_TIMESTAMP_FORMAT = nil
+    local ret = self.hooks["ChatFrame_MessageEventHandler"](...)
+    CHAT_TIMESTAMP_FORMAT = ctsf
+    return ret
+  end
 
   function module:Prat_FramesUpdated(info, name, chatFrame, ...)
     if not hookedFrames[chatFrame:GetName()] then


### PR DESCRIPTION
Previous method of hiding was disabled when Communities UI started using
the same setting as Blizzard chat timestamps.

The hook gets automatically removed by AceHook's OnEmbedDisable when the
module is disabled.