### PR TITLE
Fix for null class when chatting to BNet client

### DIFF
--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -867,7 +867,12 @@ Prat:AddModuleToLoad(function()
               message.PREPLAYERDELIM = ":"
             end
           end
-          message.PLAYER = CLR:Class(message.PLAYER, class)
+
+          if class then
+            message.PLAYER = CLR:Class(message.PLAYER, class)
+          else
+            message.PLAYER = CLR:Common(message.PLAYER)
+          end
         end
       elseif self.db.profile.realidcolor == "RANDOM" then
         message.PLAYER = CLR:Random(message.PLAYER, message.PLAYER:lower())

--- a/services/classcolor.lua
+++ b/services/classcolor.lua
@@ -16,6 +16,10 @@ function GetClassGetColor(class)
     class = GetGenderNeutralClass(class)
   end
 
+  if class == nil then
+    return nil
+  end
+
   class = class:upper()
 
   if _G.CUSTOM_CLASS_COLORS and _G.CUSTOM_CLASS_COLORS[class] then


### PR DESCRIPTION
I got a /w today from a friend using the BNet client, because he was not in game Prat was trying to do a class color on this character, which doesn't exist

Changing the function to return nil makes it render the name in white (priest), but at least it's better than having grey, or something you can't read