### PR TITLE
Guild highlighting is no longer greedy

### DIFF
--- a/modules/Highlight.lua
+++ b/modules/Highlight.lua
@@ -146,6 +146,6 @@ Prat:AddModuleToLoad(function()
 
     Prat:SetModulePatterns(module, {
         { pattern = Prat.GetNamePattern(UnitName("player")), matchfunc = highlightPlayer, priority = 100 },
-        { pattern = "<(.+)>", matchfunc = highlightGuild, priority = 100 },
+        { pattern = "<(..-)>", matchfunc = highlightGuild, priority = 100 },
     })
 end)


### PR DESCRIPTION
This ensures that the guild is only highlighted until the first greater-than sign.

Closes #37.

Before this change: 
![before](https://i.imgur.com/IysF9Xu.jpg)

After:
![after](https://i.imgur.com/f7huCep.jpg)