### PR TITLE
Fix for GuildRoster issues

### DIFF
--- a/modules/AltNames.lua
+++ b/modules/AltNames.lua
@@ -579,7 +579,12 @@ do
   function module:AutoImportGuildAlts(b)
     if b then
       self:RegisterEvent("GUILD_ROSTER_UPDATE", function() module:importGuildAlts(nil, true) end)
-      C_GuildInfo.GuildRoster()
+      -- Different functions for retail versus classic
+	  if Prat.IsRetail then
+        C_GuildInfo.GuildRoster()
+      else
+        GuildRoster()
+      end
     else
       self:UnregisterEvent("GUILD_ROSTER_UPDATE")
     end

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -458,7 +458,7 @@ Prat:AddModuleToLoad(function()
     self.NEEDS_INIT = true
 
     if IsInGuild() then
-      C_GuildInfo.GuildRoster()
+      self.GuildRoster()
     end
 
     self:TabComplete(self.db.profile.tabcomplete)
@@ -604,6 +604,17 @@ Prat:AddModuleToLoad(function()
     end
   end
 
+  -- This function is a wrapper for the Blizzard GuildRoster function, to account for the differences between Retail and Classic
+  function module:GuildRoster(...)
+    if Prat.IsRetail then
+      return C_GuildInfo.GuildRoster(...)
+    else
+      return GuildRoster(...)
+    end
+  end
+
+
+
   --[[------------------------------------------------
     Core Functions
   ------------------------------------------------]] --
@@ -626,7 +637,7 @@ Prat:AddModuleToLoad(function()
 
 
   function module:updateGF()
-    if IsInGuild() then C_GuildInfo.GuildRoster() end
+    if IsInGuild() then self.GuildRoster() end
     self:updateFriends()
     if GetNumBattlefieldScores() > 0 then
       self:updateBG()
@@ -660,7 +671,7 @@ Prat:AddModuleToLoad(function()
 
   function module:updateGuild()
     if IsInGuild() then
-      C_GuildInfo.GuildRoster()
+      self.GuildRoster()
 
       local Name, Class, Level, _
       for i = 1, GetNumGuildMembers(true) do


### PR DESCRIPTION
This fixes GuildRoster errors on Classic by checking whether the client is running on Classic or Retail and calling the appropriate GuildRoster function. This fixes #165 .