### PR TITLE
Adds 9.0 Newcomer/Guide icons

### DIFF
--- a/services/chatsections.lua
+++ b/services/chatsections.lua
@@ -540,12 +540,12 @@ function SplitChatMessage(frame, event, ...)
       elseif arg6 == "GUIDE" then
         if _G.IsActivePlayerNewcomer() then
           -- Add guide text if player is a newcomer and this was sent by a mentor
-          s.FLAG = NPEV2_CHAT_USER_TAG_GUIDE .. " "
+          s.FLAG = _G.NPEV2_CHAT_USER_TAG_GUIDE .. " "
         end
       elseif arg6 == "NEWCOMER" then
         if _G.IsActivePlayerMentor() then
           -- Add murloc icon if player is a mentor and this was sent by a new player
-          s.FLAG = NPEV2_CHAT_USER_TAG_NEWCOMER
+          s.FLAG = _G.NPEV2_CHAT_USER_TAG_NEWCOMER
         end
       else
         s.FLAG = _G["CHAT_FLAG_" .. arg6]

--- a/services/chatsections.lua
+++ b/services/chatsections.lua
@@ -534,15 +534,24 @@ function SplitChatMessage(frame, event, ...)
     if strlen(arg6) > 0 then
       s.fF = ""
 
-      -- 2.4 Change
-      if arg6 == "GM" then
-        s.FLAG = "|TInterface\\ChatFrame\\UI-ChatIcon-Blizz.blp:0:2:0:-3|t "
-      elseif (arg6 == "DEV") then
-        --Add Blizzard Icon, this was sent by a Dev
-        s.FLAG = "|TInterface\\ChatFrame\\UI-ChatIcon-Blizz.blp:0:2:0:-3|t ";
+    if arg6 ~= "" then
+      if arg6 == "GM" or arg6 == "DEV" then
+        -- Add Blizzard Icon if this was sent by a GM/DEV
+	   s.FLAG = "|TInterface\\ChatFrame\\UI-ChatIcon-Blizz:12:20:0:0:32:16:4:28:0:16|t "
+      elseif arg6 == "GUIDE" then
+        if C_PlayerMentorship.IsActivePlayerConsideredNewcomer() then
+          -- Add guide text if player is a newcomer and this was sent by a mentor
+          s.FLAG = NPEV2_CHAT_USER_TAG_GUIDE .. " "
+        end
+      elseif arg6 == "NEWCOMER" then
+        if IsActivePlayerMentor() then
+          -- Add murloc icon if player is a mentor and this was sent by a new player
+          s.FLAG = NPEV2_CHAT_USER_TAG_NEWCOMER
+        end
       else
-        s.FLAG = _G["CHAT_FLAG_" .. arg6]
+          s.FLAG = _G["CHAT_FLAG_"..arg6]
       end
+    end
 
       s.Ff = ""
     end

--- a/services/chatsections.lua
+++ b/services/chatsections.lua
@@ -534,10 +534,9 @@ function SplitChatMessage(frame, event, ...)
     if strlen(arg6) > 0 then
       s.fF = ""
 
-    if arg6 ~= "" then
       if arg6 == "GM" or arg6 == "DEV" then
         -- Add Blizzard Icon if this was sent by a GM/DEV
-	   s.FLAG = "|TInterface\\ChatFrame\\UI-ChatIcon-Blizz:12:20:0:0:32:16:4:28:0:16|t "
+	      s.FLAG = "|TInterface\\ChatFrame\\UI-ChatIcon-Blizz:12:20:0:0:32:16:4:28:0:16|t "
       elseif arg6 == "GUIDE" then
         if C_PlayerMentorship.IsActivePlayerConsideredNewcomer() then
           -- Add guide text if player is a newcomer and this was sent by a mentor
@@ -551,7 +550,6 @@ function SplitChatMessage(frame, event, ...)
       else
           s.FLAG = _G["CHAT_FLAG_"..arg6]
       end
-    end
 
       s.Ff = ""
     end

--- a/services/chatsections.lua
+++ b/services/chatsections.lua
@@ -538,7 +538,7 @@ function SplitChatMessage(frame, event, ...)
         -- Add Blizzard Icon if this was sent by a GM/DEV
 	      s.FLAG = "|TInterface\\ChatFrame\\UI-ChatIcon-Blizz:12:20:0:0:32:16:4:28:0:16|t "
       elseif arg6 == "GUIDE" then
-        if C_PlayerMentorship.IsActivePlayerConsideredNewcomer() then
+        if IsActivePlayerNewcomer() then
           -- Add guide text if player is a newcomer and this was sent by a mentor
           s.FLAG = NPEV2_CHAT_USER_TAG_GUIDE .. " "
         end

--- a/services/chatsections.lua
+++ b/services/chatsections.lua
@@ -538,17 +538,17 @@ function SplitChatMessage(frame, event, ...)
         -- Add Blizzard Icon if this was sent by a GM/DEV
 	      s.FLAG = "|TInterface\\ChatFrame\\UI-ChatIcon-Blizz:12:20:0:0:32:16:4:28:0:16|t "
       elseif arg6 == "GUIDE" then
-        if IsActivePlayerNewcomer() then
+        if _G.IsActivePlayerNewcomer() then
           -- Add guide text if player is a newcomer and this was sent by a mentor
           s.FLAG = NPEV2_CHAT_USER_TAG_GUIDE .. " "
         end
       elseif arg6 == "NEWCOMER" then
-        if IsActivePlayerMentor() then
+        if _G.IsActivePlayerMentor() then
           -- Add murloc icon if player is a mentor and this was sent by a new player
           s.FLAG = NPEV2_CHAT_USER_TAG_NEWCOMER
         end
       else
-          s.FLAG = _G["CHAT_FLAG_"..arg6]
+        s.FLAG = _G["CHAT_FLAG_" .. arg6]
       end
 
       s.Ff = ""


### PR DESCRIPTION
Fixes #148 by adding the newcomer and guide icons into the special flag check that is used to add the Blizzard icon.

See: [ChatFrame.lua lines 3397-3412](https://www.townlong-yak.com/framexml/live/ChatFrame.lua#3397)